### PR TITLE
[김민영] 2024 GDG Spring Novice Study - 2주차

### DIFF
--- a/김민영/freelec-springboot2-webservice/.idea/uiDesigner.xml
+++ b/김민영/freelec-springboot2-webservice/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/김민영/freelec-springboot2-webservice/build.gradle
+++ b/김민영/freelec-springboot2-webservice/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     // spring data jpa 의존성 추가
     implementation('com.h2database:h2')
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
+    // h2버전 다운 그레이드
+    runtimeOnly 'com.h2database:h2:1.4.197'
 }
 
 

--- a/김민영/freelec-springboot2-webservice/build.gradle
+++ b/김민영/freelec-springboot2-webservice/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.mockito', module: 'mockito-core'
     }
+
+    // spring data jpa 의존성 추가
+    implementation('com.h2database:h2')
+    implementation('org.springframework.boot:spring-boot-starter-data-jpa')
 }
 
 

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/Application.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/Application.java
@@ -2,7 +2,9 @@ package com.jojoldu.book.springboot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing  // JPA Auditing을 모두 활성화하도록 함.
 @SpringBootApplication
 public class Application {
     public static void main(String[] args){

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/BaseTimeEntity.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.jojoldu.book.springboot.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
@@ -34,5 +34,10 @@ public class Posts {
         this.content = content;
         this.author = author;
     }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }
 

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
@@ -35,6 +35,7 @@ public class Posts {
         this.author = author;
     }
 
+    // update 함수 추가
     public void update(String title, String content) {
         this.title = title;
         this.content = content;

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
@@ -1,6 +1,7 @@
 package com.jojoldu.book.springboot.domain.posts;
 
 
+import com.jojoldu.book.springboot.domain.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,8 @@ import javax.persistence.Id;
 @Getter             // 아래 2개는 lombok의 어노테이션
 @NoArgsConstructor
 @Entity   // JPA의 어노테이션
-public class Posts {
+// Posts가 BaseTimeEntity를 상속받도록 변경함.
+public class Posts extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
@@ -1,0 +1,38 @@
+package com.jojoldu.book.springboot.domain.posts;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+// Entity 클래스에서는 클래스의 인스턴스 값들의 변화를 구분하기 어렵기에 Setter 메소드를 절대 만들지 않음.
+@Getter             // 아래 2개는 lombok의 어노테이션
+@NoArgsConstructor
+@Entity   // JPA의 어노테이션
+public class Posts {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    private String author;
+
+    @Builder
+    public Posts(String title, String content, String author) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+}
+

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/PostsRepository.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/PostsRepository.java
@@ -1,0 +1,7 @@
+package com.jojoldu.book.springboot.domain.posts;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+public interface PostsRepository extends JpaRepository<Posts, Long>
+{
+
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
@@ -1,0 +1,19 @@
+package com.jojoldu.book.springboot.service.posts;
+
+
+import com.jojoldu.book.springboot.domain.posts.PostsRepository;
+import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PostsService {
+    private final PostsRepository postsRepository;
+
+    @Transactional
+    public Long save(PostsSaveRequestDto requestDto) {
+        return postsRepository.save(requestDto.toEntity()).getId();
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
@@ -1,8 +1,11 @@
 package com.jojoldu.book.springboot.service.posts;
 
 
+import com.jojoldu.book.springboot.domain.posts.Posts;
 import com.jojoldu.book.springboot.domain.posts.PostsRepository;
+import com.jojoldu.book.springboot.web.dto.PostsResponseDto;
 import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import com.jojoldu.book.springboot.web.dto.PostsUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,5 +18,21 @@ public class PostsService {
     @Transactional
     public Long save(PostsSaveRequestDto requestDto) {
         return postsRepository.save(requestDto.toEntity()).getId();
+    }
+
+    // update 함수 추가
+    @Transactional
+    public Long update(Long id, PostsUpdateRequestDto requestDto) {
+        Posts posts = postsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id="+ id));
+        posts.update(requestDto.getTitle(), requestDto.getContent());
+
+        return id;
+    }
+
+    public PostsResponseDto findById (Long id) {
+        Posts entity = postsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
+        return new PostsResponseDto(entity);
     }
 }

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
@@ -1,0 +1,21 @@
+package com.jojoldu.book.springboot.web;
+
+
+import com.jojoldu.book.springboot.service.posts.PostsService;
+import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PostsApiController {
+
+    private final PostsService postsService;
+
+    @PostMapping("/api/v1/posts")
+    public Long save(@RequestBody PostsSaveRequestDto requestDto) {
+        return postsService.save(requestDto);
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
@@ -2,11 +2,11 @@ package com.jojoldu.book.springboot.web;
 
 
 import com.jojoldu.book.springboot.service.posts.PostsService;
+import com.jojoldu.book.springboot.web.dto.PostsResponseDto;
 import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import com.jojoldu.book.springboot.web.dto.PostsUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,5 +17,16 @@ public class PostsApiController {
     @PostMapping("/api/v1/posts")
     public Long save(@RequestBody PostsSaveRequestDto requestDto) {
         return postsService.save(requestDto);
+    }
+
+    // 수정 및 조회 기능 추가
+    @PutMapping("/api/v1/posts/{id}")
+    public Long update(@PathVariable Long id, @RequestBody PostsUpdateRequestDto requestDto) {
+        return postsService.update(id, requestDto);
+    }
+
+    @GetMapping("/api/v1/posts/{id}")
+    public PostsResponseDto findById (@PathVariable Long id){
+        return postsService.findById(id);
     }
 }

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsResponseDto.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsResponseDto.java
@@ -1,0 +1,21 @@
+package com.jojoldu.book.springboot.web.dto;
+
+
+import com.jojoldu.book.springboot.domain.posts.Posts;
+import lombok.Getter;
+
+@Getter
+public class PostsResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String author;
+
+    public PostsResponseDto(Posts entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.author = entity.getAuthor();
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsSaveRequestDto.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsSaveRequestDto.java
@@ -1,0 +1,32 @@
+package com.jojoldu.book.springboot.web.dto;
+
+
+import com.jojoldu.book.springboot.domain.posts.Posts;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostsSaveRequestDto {
+
+    private String title;
+    private String content;
+    private String author;
+
+    @Builder
+    public PostsSaveRequestDto(String title, String content, String author) {
+
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+
+    public Posts toEntity() {
+        return Posts.builder()
+                .title(title)
+                .content(content)
+                .author(author)
+                .build();
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsUpdateRequestDto.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.jojoldu.book.springboot.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostsUpdateRequestDto {
+    private String title;
+    private String content;
+
+    @Builder
+    public PostsUpdateRequestDto(String title, String content) {
+
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
+++ b/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jpa.show_sql=true

--- a/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
+++ b/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
 spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 spring.datasource.hikari.jdbc-url=jdbc:h2:mem://localhost/~/testdb;MODE=MYSQL
+spring.h2.console.enabled=true

--- a/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
+++ b/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-spring.jpa.show_sql=true
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
+spring.jpa.properties.hibernate.dialect.storage_engine=innodb
+spring.datasource.hikari.jdbc-url=jdbc:h2:mem://localhost/~/testdb;MODE=MYSQL

--- a/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
+++ b/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.jojoldu.book.springboot.domain.posts;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class PostsRepositoryTest {
+
+    @Autowired
+    PostsRepository postsRepository;
+
+    @AfterEach
+    public void cleanup() {
+        postsRepository.deleteAll();
+    }
+
+    @Test
+    public void 게시글저장_불러오기() {
+        //given
+        String title = "테스트 게시글";
+        String content = "테스트 본문";
+
+        postsRepository.save(Posts.builder()
+                .title(title)
+                .content(content)
+                .author("jojoldu@gmail.com")
+                .build());
+
+        //when
+        List<Posts> postsList = postsRepository.findAll();
+
+        //then
+        Posts posts = postsList.get(0);
+        assertThat(posts.getTitle()).isEqualTo(title);
+        assertThat(posts.getContent()).isEqualTo(content);
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
+++ b/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,5 +42,30 @@ public class PostsRepositoryTest {
         Posts posts = postsList.get(0);
         assertThat(posts.getTitle()).isEqualTo(title);
         assertThat(posts.getContent()).isEqualTo(content);
+    }
+
+    // JPA Auditing 테스트 코드 추가
+    @Test
+    public void BaseTimeEntity_등록() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2019,6,4,0,0,0);
+        postsRepository.save(Posts.builder()
+                .title("title")
+                .content("content")
+                .author("author")
+                .build());
+
+        //when
+        List<Posts> postsList = postsRepository.findAll();
+
+        //then
+        Posts posts = postsList.get(0);
+
+        System.out.println(">>>>>>>>> createDate="+posts.getCreatedDate()+", modifiedDate="+posts.getModifiedDate());
+
+        assertThat(posts.getCreatedDate()).isAfter(now);
+        assertThat(posts.getModifiedDate()).isAfter(now);
+
+
     }
 }

--- a/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
+++ b/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
@@ -1,0 +1,70 @@
+package com.jojoldu.book.springboot.web;
+
+
+import com.jojoldu.book.springboot.domain.posts.Posts;
+import com.jojoldu.book.springboot.domain.posts.PostsRepository;
+import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PostsApiControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PostsRepository postsRepository;
+
+    @AfterEach
+    public void testDown() throws Exception {
+        postsRepository.deleteAll();
+    }
+
+    @Test
+    public void Posts_등록된다() throws Exception {
+        //given
+        String title = "title";
+        String content = "content";
+        PostsSaveRequestDto requestDto = PostsSaveRequestDto.builder()
+                .title(title)
+                .content(content)
+                .author("author")
+                .build();
+
+        String url = "http://localhost:" + port + "/api/v1/posts";
+
+        //when
+        ResponseEntity<Long> responseEntity = restTemplate.
+                postForEntity(url, requestDto, Long.class);
+
+        //then
+        assertThat(responseEntity.getStatusCode()).
+                isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).
+                isGreaterThan(0L);
+
+        List<Posts> all = postsRepository.findAll();
+        assertThat(all.get(0).getTitle()).isEqualTo(title);
+        assertThat(all.get(0).getContent()).isEqualTo(content);
+    }
+
+}

--- a/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
+++ b/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
@@ -5,6 +5,7 @@ import com.jojoldu.book.springboot.domain.posts.Posts;
 import com.jojoldu.book.springboot.domain.posts.PostsRepository;
 import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
 
+import com.jojoldu.book.springboot.web.dto.PostsUpdateRequestDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +14,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -65,6 +68,46 @@ public class PostsApiControllerTest {
         List<Posts> all = postsRepository.findAll();
         assertThat(all.get(0).getTitle()).isEqualTo(title);
         assertThat(all.get(0).getContent()).isEqualTo(content);
+    }
+
+    // 수정 기능 테스트 코드 추가
+
+    @Test
+    public void Posts_수정된다() throws Exception {
+        //given
+        Posts savedPosts = postsRepository.save(Posts.builder()
+                .title("title")
+                .content("content")
+                .author("author")
+                .build());
+
+        Long updateId = savedPosts.getId();
+        String expectedTitle = "title2";
+        String expectedContent = "content2";
+
+        PostsUpdateRequestDto requestDto = PostsUpdateRequestDto.builder()
+                .title(expectedTitle)
+                .content(expectedContent)
+                .build();
+
+        String url = "http://localhost:" + port + "/api/v1/posts/"+ updateId;
+
+        HttpEntity<PostsUpdateRequestDto> requestEntity = new HttpEntity<>(requestDto);
+
+        //when
+        ResponseEntity<Long> responseEntity = restTemplate.
+                exchange(url, HttpMethod.PUT,
+                        requestEntity, Long.class);
+
+        //then
+        assertThat(responseEntity.getStatusCode())
+                .isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isGreaterThan(0L);
+        List<Posts> all = postsRepository.findAll();
+        assertThat(all.get(0).getTitle())
+                .isEqualTo(expectedTitle);
+        assertThat(all.get(0).getContent())
+                .isEqualTo(expectedContent);
     }
 
 }


### PR DESCRIPTION
## 📒 개요

3장 : 스프링 부트에서 JPA로 데이터베이스 다뤄보자
* JPA/Hibernate/Spring Data Jpa의 관계
* Spring Data Jpa를 이용하여 관계형 데이터베이스를 객체지향적으로 관리하는 방법
* JPA의 더티 체킹을 이용하면 Update 쿼리 없이 테이블 수정이 가능하다는 것
* JPA Auditing을 이용하여 등록/수정 시간을 자동화 하는 방법


## 👀 새롭게 배운 점

- 실제로 개발하면서 SQL 다루는 시간이 많이 소요되었던 경험이 있었는데, 테이블 모델링 자체에 집중하는 것보다 개발에 집중할 수 있도록 JPA이라는 자바의 표준 객체 관계형 매핑 기술이 있다는 점
- 데이터베이스를 사용하지 않는 서비스는 없기에, 객체를 관계형 데이터베이스에서 관리하는 것이 중요한데, 프로그램에서의 객체지향과는 언어의 패러다임이 크다는 점, 이것을 패러다임 불일치라고 한다.
- JPA는 지향점이 다른 객체지향 프로그래밍 언어와 관계형 데이터베이스를 중간에서 패러다임 일치를 시켜주는 기술임. 
- Spring에서는 JPA 구현체를 직접 다루지 않고 Spring Data JPA 모듈을 사용해서 기술을 다룬다.
-

## 📍 추가적인 질문

- 1) 교재 116페이지에서 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect 관련 오류가 발생해서 노션에서 알려주신 바와 같이, 
`spring.jpa.show-sql=true
spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
spring.jpa.properties.hibernate.dialect.storage_engine=innodb
spring.datasource.hikari.jdbc-url=jdbc:h2:mem://localhost/~/testdb;MODE=MYSQL`
이렇게 수정해서 해결하였는데, 원인과 해결방법의 이유가 궁금합니다! 혹시 h2데이터베이스 사용과 관련되어있을까요? 

## 💡 느낀 점
- 1,2장에서의 개발환경 세팅과 초기 프로젝트 세팅 과정에서는 정말 오류들도 많았고 해결하는 데에도 많은 시간이 걸렸지만, 그만큼 오류들에 대해 익숙해지고 원인과 해결방법을 한 번 익히고 나니 이번 2주차에는 보다 수월하게 실습을 진행할 수 있었습니다. 
- 또한 실습을 진행하기 전에는 2주차의 레퍼런스가 이해하기 어려웠는데, 실습 중간이나 끝난 이후에 정독해보니 훨씬 이해도 잘 되고 배운 내용을 복습할 수 있었던 것 같습니다. 
- 그리고 미리 노션에 정리해주신 부분들이 있었기에 서치에 많은 시간을 쏟지 않을 수 있어서 큰 도움이 되었습니다. 
- 사실 모든 코드들의 쓰임새와 의미를 완전히 이해하고 있지는 못하지만, 반복되는 구조나 어노테이션 등에 대해서 1주차보다 더 이해도가 높아졌다고 생각했습니다. 이후 3주차부터는 실습 진행 후 코드에 주석을 추가하면서 코드 이해도를 높이면 더 좋을 것 같다고 생각합니다! 
