### PR TITLE
[이예지] 2024 GDG Spring Novice Study - 2주차

### DIFF
--- a/이예지/freelec-springboot2-webservice/build.gradle
+++ b/이예지/freelec-springboot2-webservice/build.gradle
@@ -34,9 +34,12 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web' // 웹 관련 의존성 추가
 	implementation 'org.projectlombok:lombok'  // 롬복 추가
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // 스프링 부트용 Spring Data JPA 추상화 라이브러리
+	implementation 'com.h2database:h2' // 인메모리 관계형 데이터베이스
 	annotationProcessor 'org.projectlombok:lombok' // 롬복 어노테이션 프로세서
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 }
 
 test {

--- a/이예지/freelec-springboot2-webservice/build.gradle
+++ b/이예지/freelec-springboot2-webservice/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	runtimeOnly 'com.h2database:h2:1.4.197' // h2 버전 낮추기
+
 }
 
 test {

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/Application.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/Application.java
@@ -2,7 +2,9 @@ package com.jojoldu.book.springboot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/BaseTimeEntity.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.jojoldu.book.springboot.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
@@ -28,4 +28,9 @@ public class Posts {
         this.content = content;
         this.author = author;
     }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
@@ -1,5 +1,6 @@
 package com.jojoldu.book.springboot.domain.posts;
 
+import com.jojoldu.book.springboot.domain.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Posts {
+public class Posts extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy =  GenerationType.IDENTITY)
     private Long id;

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/Posts.java
@@ -1,0 +1,31 @@
+package com.jojoldu.book.springboot.domain.posts;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Posts {
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    private String author;
+
+    @Builder
+    public Posts(String title, String content, String author) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+}

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/PostsRepository.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/domain/posts/PostsRepository.java
@@ -1,0 +1,7 @@
+package com.jojoldu.book.springboot.domain.posts;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostsRepository extends JpaRepository<Posts, Long> {
+
+}

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
@@ -1,0 +1,19 @@
+package com.jojoldu.book.springboot.service.posts;
+
+import com.jojoldu.book.springboot.domain.posts.PostsRepository;
+import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PostsService {
+    private final PostsRepository postsRepository;
+
+    @Transactional
+    public Long save(PostsSaveRequestDto requestDto) {
+        return postsRepository.save(requestDto.toEntity()).getId();
+    }
+}

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/service/posts/PostsService.java
@@ -1,7 +1,10 @@
 package com.jojoldu.book.springboot.service.posts;
 
+import com.jojoldu.book.springboot.domain.posts.Posts;
 import com.jojoldu.book.springboot.domain.posts.PostsRepository;
+import com.jojoldu.book.springboot.web.dto.PostsResponseDto;
 import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import com.jojoldu.book.springboot.web.dto.PostsUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +18,20 @@ public class PostsService {
     @Transactional
     public Long save(PostsSaveRequestDto requestDto) {
         return postsRepository.save(requestDto.toEntity()).getId();
+    }
+
+    @Transactional
+    public Long update(Long id, PostsUpdateRequestDto requestDto) {
+        Posts posts = postsRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
+
+        posts.update(requestDto.getTitle(), requestDto.getContent());
+
+        return  id;
+    }
+
+    public PostsResponseDto findById (Long id) {
+        Posts entity = postsRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
+
+        return new PostsResponseDto(entity);
     }
 }

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/HelloController.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/HelloController.java
@@ -3,7 +3,6 @@ package com.jojoldu.book.springboot.web;
 import com.jojoldu.book.springboot.web.dto.HelloResponseDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
@@ -1,0 +1,21 @@
+package com.jojoldu.book.springboot.web;
+
+import com.jojoldu.book.springboot.service.posts.PostsService;
+import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PostsApiController {
+
+    private final PostsService postsService;
+
+    @PostMapping("/api/v1/posts")
+    public Long save(@RequestBody PostsSaveRequestDto requestDto) {
+
+        return postsService.save(requestDto);
+    }
+}

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/PostsApiController.java
@@ -1,11 +1,11 @@
 package com.jojoldu.book.springboot.web;
 
 import com.jojoldu.book.springboot.service.posts.PostsService;
+import com.jojoldu.book.springboot.web.dto.PostsResponseDto;
 import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import com.jojoldu.book.springboot.web.dto.PostsUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,5 +17,15 @@ public class PostsApiController {
     public Long save(@RequestBody PostsSaveRequestDto requestDto) {
 
         return postsService.save(requestDto);
+    }
+
+    @PutMapping("/api/v1/posts/{id}")
+    public Long update(@PathVariable Long id, @RequestBody PostsUpdateRequestDto requestDto) {
+        return postsService.update(id, requestDto);
+    }
+
+    @GetMapping("/api/v1/posts/{id}")
+    public PostsResponseDto findById (@PathVariable Long id) {
+        return postsService.findById(id);
     }
 }

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsResponseDto.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsResponseDto.java
@@ -1,0 +1,19 @@
+package com.jojoldu.book.springboot.web.dto;
+
+import com.jojoldu.book.springboot.domain.posts.Posts;
+import lombok.Getter;
+
+@Getter
+public class PostsResponseDto {
+    private long id;
+    private String title;
+    private String content;
+    private String author;
+
+    public PostsResponseDto(Posts entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.author = entity.getAuthor();
+    }
+}

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsSaveRequestDto.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsSaveRequestDto.java
@@ -1,0 +1,30 @@
+package com.jojoldu.book.springboot.web.dto;
+
+import com.jojoldu.book.springboot.domain.posts.Posts;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostsSaveRequestDto {
+    private String title;
+    private String content;
+    private String author;
+
+    @Builder
+    public PostsSaveRequestDto(String title, String content, String author) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+
+    public Posts toEntity() {
+        return Posts.builder()
+                .title(title)
+                .content(content)
+                .author(author)
+                .build();
+    }
+
+}

--- a/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsUpdateRequestDto.java
+++ b/이예지/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/dto/PostsUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.jojoldu.book.springboot.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostsUpdateRequestDto {
+    private String title;
+    private String content;
+
+    @Builder
+    public PostsUpdateRequestDto(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/이예지/freelec-springboot2-webservice/src/main/resources/application.properties
+++ b/이예지/freelec-springboot2-webservice/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=freelec-springboot2-webservice
 spring.jpa.show-sql=true
 
 # ???? ?? ??? MySQL ???? ??
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 spring.datasource.hikari.jdbc-url=jdbc:h2:mem://localhost/~/testdb;MODE=MYSQL
 

--- a/이예지/freelec-springboot2-webservice/src/main/resources/application.properties
+++ b/이예지/freelec-springboot2-webservice/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=freelec-springboot2-webservice
+
+# ??? ??? ?? ??
+spring.jpa.show-sql=true
+
+# ???? ?? ??? MySQL ???? ??
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
+spring.jpa.properties.hibernate.dialect.storage_engine=innodb
+spring.datasource.hikari.jdbc-url=jdbc:h2:mem://localhost/~/testdb;MODE=MYSQL

--- a/이예지/freelec-springboot2-webservice/src/main/resources/application.properties
+++ b/이예지/freelec-springboot2-webservice/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
 spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 spring.datasource.hikari.jdbc-url=jdbc:h2:mem://localhost/~/testdb;MODE=MYSQL
+
+# ? ?? ?? ???
+spring.h2.console.enabled=true

--- a/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
+++ b/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.jojoldu.book.springboot.domain.posts;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class PostsRepositoryTest {
+
+    @Autowired
+    PostsRepository postsRepository;
+
+    @AfterEach
+    public void cleanup() {
+        postsRepository.deleteAll();
+    }
+
+    @Test
+    public void 게시글저장_불러오기() {
+        //given
+        String title = "테스트 게시글";
+        String content = "테스트 본문";
+
+        postsRepository.save(Posts.builder()
+                .title(title)
+                .content(content)
+                .author("jojoldu@gmail.com")
+                .build());
+
+        //when
+        List<Posts> postsList = postsRepository.findAll();
+
+        //then
+        Posts posts = postsList.get(0);
+        assertThat(posts.getTitle()).isEqualTo(title);
+        assertThat(posts.getContent()).isEqualTo(content);
+    }
+}

--- a/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
+++ b/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/domain/posts/PostsRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,5 +43,26 @@ public class PostsRepositoryTest {
         Posts posts = postsList.get(0);
         assertThat(posts.getTitle()).isEqualTo(title);
         assertThat(posts.getContent()).isEqualTo(content);
+    }
+
+    @Test
+    public void BaseTimeEntity_등록() {
+        //given
+        LocalDateTime now = LocalDateTime.of(2019,6,4,0,0,0);
+        postsRepository.save(Posts.builder()
+                .title("title")
+                .content("content")
+                .author("author")
+                .build());
+        //when
+        List<Posts> postsList = postsRepository.findAll();
+
+        //then
+        Posts posts = postsList.get(0);
+
+        System.out.println(">>>>>>>> createDate="+posts.getCreatedDate()+", modifiedDate="+posts.getModifiedDate());
+
+        assertThat(posts.getCreatedDate()).isAfter(now);
+        assertThat(posts.getModifiedDate()).isAfter(now);
     }
 }

--- a/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/HelloControllerTest.java
+++ b/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/HelloControllerTest.java
@@ -1,4 +1,4 @@
-package com.jojoldu.book.springboot;
+package com.jojoldu.book.springboot.web;
 
 import com.jojoldu.book.springboot.web.HelloController;
 import org.junit.jupiter.api.Test;

--- a/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
+++ b/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
@@ -3,6 +3,7 @@ package com.jojoldu.book.springboot.web;
 import com.jojoldu.book.springboot.domain.posts.Posts;
 import com.jojoldu.book.springboot.domain.posts.PostsRepository;
 import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import com.jojoldu.book.springboot.web.dto.PostsUpdateRequestDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -59,5 +62,39 @@ public class PostsApiControllerTest {
         List<Posts> all = postsRepository.findAll();
         assertThat(all.get(0).getTitle()).isEqualTo(title);
         assertThat(all.get(0).getContent()).isEqualTo(content);
+    }
+
+    @Test
+    public void Posts_수정된다() throws Exception {
+        //given
+        Posts savedPosts = postsRepository.save(Posts.builder()
+                .title("title")
+                .content("content")
+                .author("author")
+                .build());
+
+        Long updateId = savedPosts.getId();
+        String expectedTitle = "title2";
+        String expectedContent = "content2";
+
+        PostsUpdateRequestDto requestDto = PostsUpdateRequestDto.builder()
+                .title(expectedTitle)
+                .content(expectedContent)
+                .build();
+
+        String url = "http://localhost:" + port + "/api/v1/posts/" + updateId;
+
+        HttpEntity<PostsUpdateRequestDto> requestsEntity = new HttpEntity<>(requestDto);
+
+        //when
+        ResponseEntity<Long> responseEntity = restTemplate.exchange(url, HttpMethod.PUT, requestsEntity, Long.class);
+
+        //then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isGreaterThan(0L);
+
+        List<Posts> all = postsRepository.findAll();
+        assertThat(all.get(0).getTitle()).isEqualTo(expectedTitle);
+        assertThat(all.get(0).getContent()).isEqualTo(expectedContent);
     }
 }

--- a/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
+++ b/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
@@ -1,0 +1,63 @@
+package com.jojoldu.book.springboot.web;
+
+import com.jojoldu.book.springboot.domain.posts.Posts;
+import com.jojoldu.book.springboot.domain.posts.PostsRepository;
+import com.jojoldu.book.springboot.web.dto.PostsSaveRequestDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PostsApiControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PostsRepository postsRepository;
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        postsRepository.deleteAll();
+    }
+
+    @Test
+    public void Posts_등록된다() throws Exception {
+        //given
+        String title = "title";
+        String content = "content";
+        PostsSaveRequestDto requestDto = PostsSaveRequestDto.builder()
+                .title(title)
+                .content(content)
+                .author("author")
+                .build();
+
+        String url = "http://localhost:" + port + "/api/v1/posts";
+
+        //when
+        ResponseEntity<Long> responseEntity = restTemplate.postForEntity(url, requestDto, Long.class);
+
+        //then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isGreaterThan(0L);
+
+        List<Posts> all = postsRepository.findAll();
+        assertThat(all.get(0).getTitle()).isEqualTo(title);
+        assertThat(all.get(0).getContent()).isEqualTo(content);
+    }
+}

--- a/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/dto/HelloResponseDtoTest.java
+++ b/이예지/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/dto/HelloResponseDtoTest.java
@@ -1,6 +1,5 @@
-package com.jojoldu.book.springboot.dto;
+package com.jojoldu.book.springboot.web.dto;
 
-import com.jojoldu.book.springboot.web.dto.HelloResponseDto;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## 📒 개요

3장 - 스프링 부트에서 JPA로 데이터베이스 다뤄보자
- JPA란
- CRUD 실습
  - 프로젝트에 Spring Data JPA 적용
  - Spring Data JPA 테스트 코드 작성하기
  - 등록/수정/조회 API 만들기
  - JPA Auditing으로 생성시간/수정시간 자동화

<br/>

## 👀 새롭게 배운 점

이번 주차 내용을 공부하며 정리한 노션입니다.
https://knotty-battery-836.notion.site/JPA-113e7cbb232180c1925bd61b988523d8?pvs=4

<br/>

## 📍 추가적인 질문

디스코드에 올려주신 POSTS 테이블을 찾을 수 없다는 오류를 저도 마주했습니다. 저는 저희 스터디 노션의 교재 실습 설명에 적혀있는 부분을 먼저 읽고 실습을 진행해서 application.properties에 
`spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect`
이렇게 작성해두었다가, 오류가 발생해서 교재에 나온대로
`spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect`
변경해주었더니 테스트 실행에 통과했습니다.
두가지의 차이점과 오류 발생 이유가 궁금해서 찾아보던 중 관련된 것처럼 보이는 이슈를 읽었는데도 잘 이해가 되지 않아 질문 드립니다.
https://github.com/jojoldu/freelec-springboot2-webservice/issues/67
버전의 차이가 문제가 되어서 테이블 자체가 생성이 되지 않은 것인가요?!

<br/>

## 🙂 느낀점
그동안 다른 파트를 해오면서 백엔드가 데이터베이스에 어떻게 접근하는지 궁금했었는데, JPA에 대해서 공부하면서 궁금증이 해결된 것 같습니다. 직접 sql 쿼리를 작성하지 않아도 된다는 점과 데이터지향, 객체지향 두가지의 패러다임을 이어준다는 점이 흥미로웠고 JPA가 스프링의 굉장한 이점이라는 것을 깨달을 수 있었습니다. 아직까지는 낯설고 아리송한 부분들이 있지만, 점점 이런 개념들에 자주 노출되고 꾸준히 실습하다보면 익숙해질 것 같습니다. 그런 의미에서 이번 주차 레퍼런스가 이해에 많은 도움이 된 것 같습니다. 감사합니다! 
