### PR TITLE
[김민영] 2024 GDG Spring Novice Study - 4주차

### DIFF
--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/Application.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/Application.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing  // JPA Auditing을 모두 활성화하도록 함.
+// @EnableJpaAuditing 제거
+// @EnableJpaAuditing  // JPA Auditing을 모두 활성화하도록 함.
 @SpringBootApplication
 public class Application {
     public static void main(String[] args){
+
         SpringApplication.run(Application.class, args);
     }
 }

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/JpaConfig.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.jojoldu.book.springboot.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/WebConfig.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.jojoldu.book.springboot.config;
+
+
+import com.jojoldu.book.springboot.config.auth.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/CustomOAuth2UserService.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/CustomOAuth2UserService.java
@@ -1,0 +1,59 @@
+package com.jojoldu.book.springboot.config.auth;
+
+import com.jojoldu.book.springboot.domain.user.User;
+import com.jojoldu.book.springboot.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import javax.websocket.Session;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest)
+        throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User>
+                delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        String registrationId = userRequest.
+                getClientRegistration()
+                .getRegistrationId();
+        String userNameAttributeName = userRequest.
+                getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().
+                getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.
+                of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        User user = saveOrUpdate(attributes);
+
+        httpSession.setAttribute("user", new Session(user));
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+                attributes.getAttributes(),
+                attributes.getNameAttributekey()
+        );
+    }
+
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
+                .orElse(attributes.toEntity());
+        return userRepository.save(user);
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/CustomOAuth2UserService.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.jojoldu.book.springboot.config.auth;
 
+import com.jojoldu.book.springboot.config.auth.dto.OAuthAttributes;
 import com.jojoldu.book.springboot.domain.user.User;
 import com.jojoldu.book.springboot.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,12 +42,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         User user = saveOrUpdate(attributes);
 
-        httpSession.setAttribute("user", new Session(user));
+        httpSession.setAttribute("user", new SessionUser(user));
 
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
                 attributes.getAttributes(),
-                attributes.getNameAttributekey()
+                attributes.getNameAttributeKey()
         );
     }
 

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/CustomOAuth2UserService.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.jojoldu.book.springboot.config.auth;
 
 import com.jojoldu.book.springboot.config.auth.dto.OAuthAttributes;
+import com.jojoldu.book.springboot.config.auth.dto.SessionUser;
 import com.jojoldu.book.springboot.domain.user.User;
 import com.jojoldu.book.springboot.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/LoginUser.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/LoginUser.java
@@ -1,0 +1,11 @@
+package com.jojoldu.book.springboot.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/LoginUserArgumentResolver.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.jojoldu.book.springboot.config.auth;
+
+import com.jojoldu.book.springboot.config.auth.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpSession;
+import javax.sound.midi.MetaEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final HttpSession httpSession;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isLoginUserAnnotation = parameter.getParameterAnnotation(LoginUser.class) != null;
+        boolean isUserClass = SessionUser.class.equals(parameter.getParameterType());
+        return isLoginUserAnnotation && isUserClass;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        return httpSession.getAttribute("user");
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/SecurityConfig.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/SecurityConfig.java
@@ -20,11 +20,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .authorizeRequests()
                     .antMatchers("/", "/css/**", "/images/**",
                             "/js/**", "/h2-console/**").permitAll()
-                    .antMachers("/api/v1/**").hasRole(Role.USER.name())
+                    .antMatchers("/api/v1/**").hasRole(Role.USER.name())
                     .anyRequest().authenticated()
                     .and()
                     .logout()
-                    .logoutSeccessUrl("/")
+                    .logoutSuccessUrl("/")
                     .and()
                     .oauth2Login()
                     .userInfoEndpoint()

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/dto/OAuthAttributes.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/dto/OAuthAttributes.java
@@ -1,0 +1,56 @@
+package com.jojoldu.book.springboot.config.auth.dto;
+
+import com.jojoldu.book.springboot.domain.user.Role;
+import com.jojoldu.book.springboot.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes,
+                           String nameAttributeKey,
+                           String name,
+                           String email,
+                           String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .picture(picture)
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/dto/OAuthAttributes.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/dto/OAuthAttributes.java
@@ -32,6 +32,10 @@ public class OAuthAttributes {
     public static OAuthAttributes of(String registrationId,
                                      String userNameAttributeName,
                                      Map<String, Object> attributes) {
+
+        if ("naver".equals(registrationId)) {
+            return ofNaver("id", attributes);
+        }
         return ofGoogle(userNameAttributeName, attributes);
     }
 
@@ -41,6 +45,19 @@ public class OAuthAttributes {
                 .email((String) attributes.get("email"))
                 .picture((String) attributes.get("picture"))
                 .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>)
+                attributes.get("response");
+
+        return OAuthAttributes.builder()
+                .name((String) response.get("name"))
+                .email((String) response.get("email"))
+                .picture((String) response.get("profile_image"))
+                .attributes(response)
                 .nameAttributeKey(userNameAttributeName)
                 .build();
     }

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/dto/SessionUser.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/config/auth/dto/SessionUser.java
@@ -1,0 +1,19 @@
+package com.jojoldu.book.springboot.config.auth.dto;
+
+import com.jojoldu.book.springboot.domain.user.User;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class SessionUser implements Serializable {
+    private String name;
+    private String email;
+    private String picture;
+
+    public SessionUser(User user) {
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.picture = user.getPicture();
+    }
+}

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/IndexController.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/IndexController.java
@@ -1,5 +1,6 @@
 package com.jojoldu.book.springboot.web;
 
+import com.jojoldu.book.springboot.config.auth.LoginUser;
 import com.jojoldu.book.springboot.config.auth.dto.SessionUser;
 import com.jojoldu.book.springboot.service.posts.PostsService;
 import com.jojoldu.book.springboot.web.dto.PostsResponseDto;
@@ -19,10 +20,9 @@ public class IndexController {
     private final HttpSession httpSession;
 
     @GetMapping("/")
-    public String index(Model model) {
+    public String index(Model model, @LoginUser SessionUser user) {
         model.addAttribute("posts", postsService.findAllDesc());
 
-        SessionUser user = (SessionUser) httpSession.getAttribute("user");
         if (user != null) {
             model.addAttribute("userName", user.getName());
         }

--- a/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/IndexController.java
+++ b/김민영/freelec-springboot2-webservice/src/main/java/com/jojoldu/book/springboot/web/IndexController.java
@@ -1,5 +1,6 @@
 package com.jojoldu.book.springboot.web;
 
+import com.jojoldu.book.springboot.config.auth.dto.SessionUser;
 import com.jojoldu.book.springboot.service.posts.PostsService;
 import com.jojoldu.book.springboot.web.dto.PostsResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -8,15 +9,23 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import javax.servlet.http.HttpSession;
+
 @RequiredArgsConstructor
 @Controller
 public class IndexController {
 
     private final PostsService postsService;
+    private final HttpSession httpSession;
 
     @GetMapping("/")
     public String index(Model model) {
         model.addAttribute("posts", postsService.findAllDesc());
+
+        SessionUser user = (SessionUser) httpSession.getAttribute("user");
+        if (user != null) {
+            model.addAttribute("userName", user.getName());
+        }
         return "index";
     }
 

--- a/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
+++ b/김민영/freelec-springboot2-webservice/src/main/resources/application.properties
@@ -4,3 +4,9 @@ spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 spring.datasource.hikari.jdbc-url=jdbc:h2:mem://localhost/~/testdb;MODE=MYSQL
 spring.h2.console.enabled=true
 spring.profiles.include=oauth
+
+#Test OAuth
+
+spring.security.oauth2.client.registration.google.client-id=test
+spring.security.oauth2.client.registration.google.client-secret=test
+spring.security.oauth2.client.registration.google.scope=profile,email

--- a/김민영/freelec-springboot2-webservice/src/main/resources/templates/index.mustache
+++ b/김민영/freelec-springboot2-webservice/src/main/resources/templates/index.mustache
@@ -12,6 +12,7 @@
             {{/userName}}
             {{^userName}}
                 <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
+                <a href="/oauth2/authorization/naver" class="btn btn-secondary active" role="button">Naver Login</a>
             {{/userName}}
         </div>
     </div>

--- a/김민영/freelec-springboot2-webservice/src/main/resources/templates/index.mustache
+++ b/김민영/freelec-springboot2-webservice/src/main/resources/templates/index.mustache
@@ -2,11 +2,20 @@
 
 <h1>스프링 부트로 시작하는 웹 서비스</h1>
 <div class="col-md-12">
+    <!-- 로그인 기능 영역 -->
     <div class="row">
         <div class="col-md-6">
             <a href="/posts/save" role="button" class="btn btn-primary">글 등록</a>
+            {{#userName}}
+                    Logged in as: <span id="user">{{userName}}</span>
+                <a href="/logout" class="btn btn-info active" role="button">Logout</a>
+            {{/userName}}
+            {{^userName}}
+                <a href="/oauth2/authorication/google" class="btn btn-success active" role="button">Google Login</a>
+            {{/userName}}
         </div>
     </div>
+    <br>
     <!-- 목록 출력 영역 -->
     <table class="table table-horizontal table-bordered">
         <thead class="thead-strong">

--- a/김민영/freelec-springboot2-webservice/src/main/resources/templates/index.mustache
+++ b/김민영/freelec-springboot2-webservice/src/main/resources/templates/index.mustache
@@ -11,7 +11,7 @@
                 <a href="/logout" class="btn btn-info active" role="button">Logout</a>
             {{/userName}}
             {{^userName}}
-                <a href="/oauth2/authorication/google" class="btn btn-success active" role="button">Google Login</a>
+                <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
             {{/userName}}
         </div>
     </div>

--- a/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/HelloControllerTest.java
+++ b/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/HelloControllerTest.java
@@ -1,10 +1,14 @@
 package com.jojoldu.book.springboot.web;
 
 
+import com.jojoldu.book.springboot.config.auth.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -15,11 +19,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(controllers = HelloController.class)
+//SecurityConfig 제거
+@WebMvcTest(controllers = HelloController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+})
 public class HelloControllerTest {
     @Autowired
     private MockMvc mvc;
 
+    //임의의 사용자 인증 추가
+    @WithMockUser(roles="USER")
     @Test
     public void hello가_리턴된다() throws Exception {
         String hello = "hello";
@@ -29,6 +38,8 @@ public class HelloControllerTest {
                 .andExpect(content().string(hello));
     }
     // hello dto 코드 추가
+    //임의의 사용자 인증 추가
+    @WithMockUser(roles="USER")
     @Test
     public void helloDto가_리턴된다() throws Exception {
         String name = "hello";

--- a/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
+++ b/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
@@ -43,6 +44,8 @@ public class PostsApiControllerTest {
     }
 
     @Test
+    //임의의 사용자 인증 추가
+    @WithMockUser(roles="USER")
     public void Posts_등록된다() throws Exception {
         //given
         String title = "title";
@@ -73,6 +76,8 @@ public class PostsApiControllerTest {
     // 수정 기능 테스트 코드 추가
 
     @Test
+    //임의의 사용자 인증 추가
+    @WithMockUser(roles="USER")
     public void Posts_수정된다() throws Exception {
         //given
         Posts savedPosts = postsRepository.save(Posts.builder()

--- a/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
+++ b/김민영/freelec-springboot2-webservice/src/test/java/com/jojoldu/book/springboot/web/PostsApiControllerTest.java
@@ -27,6 +27,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put; // 올바른 import
+
+
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class PostsApiControllerTest {
@@ -74,8 +77,8 @@ public class PostsApiControllerTest {
         String url = "http://localhost:" + port + "/api/v1/posts";
 
         // when
-        mvc.perform(post(url) // MockMvcRequestBuilders.post() 사용
-                        .contentType(MediaType.APPLICATION_JSON) // MediaType 수정
+        mvc.perform(post(url)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
                         .content(new ObjectMapper().writeValueAsString(requestDto)))
                 .andExpect(status().isOk());
 
@@ -111,18 +114,14 @@ public class PostsApiControllerTest {
         HttpEntity<PostsUpdateRequestDto> requestEntity = new HttpEntity<>(requestDto);
 
         // when
-        ResponseEntity<Long> responseEntity = restTemplate.
-                exchange(url, HttpMethod.PUT,
-                        requestEntity, Long.class);
+        mvc.perform(put(url)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .content(new ObjectMapper().writeValueAsString(requestDto)))
+                .andExpect(status().isOk());
 
         // then
-        assertThat(responseEntity.getStatusCode())
-                .isEqualTo(HttpStatus.OK);
-        assertThat(responseEntity.getBody()).isGreaterThan(0L);
         List<Posts> all = postsRepository.findAll();
-        assertThat(all.get(0).getTitle())
-                .isEqualTo(expectedTitle);
-        assertThat(all.get(0).getContent())
-                .isEqualTo(expectedContent);
+        assertThat(all.get(0).getTitle()).isEqualTo(expectedTitle);
+        assertThat(all.get(0).getContent()).isEqualTo(expectedContent);
     }
 }


### PR DESCRIPTION
## 📒 개요

5장 : 스프링 시큐리티와 OAuth 2.0으로 로그인 기능 구현하기
- 스프링부트 1.5와 스프링부트 2.0에서 시큐리티 설정의 차이점
- 스프링 시큐리티를 이용한 구글/네이버 로그인 연동 방법
- 세션 저장소로 톰캣/데이터베이스/메모리 DB가 있으며 이 중 데이터베이스를 사용하는 이유
- ArgumentResolver를 이용하면 어노테이션으로 로그인 세션 정보를 가져올 수 있다는 것
- 스프링 시큐리티 적용 시 기존 테스트 코드에서 문제 해결 방법

## 👀 새롭게 배운 점

- 구글 및 네이버 로그인을 위해서 사용자 인증 처리 과정이 중요함을 알게 되었습니다.
- 저장소 사용에 있어서 각각 방법마다의 사용하는 상황에 대해서 알아볼 수 있었습니다.
- 추가로 기존 테스트 코드에서 오류들이 많이 발생했는데 순차적으로 해결하는 과정에서 시큐리티 적용에 대해서도 알 수 있었습니다. 

## 📍 추가적인 질문

1) 교재 206-207페이지에서 application-oauth.properties를 수정할 때 교재와 동일하게 진행하고, 클라이언트ID와 비밀번호를 넣었음에도 오류가 발생해서 spring 프로젝트 자체가 계속 강제 종료되는 문제가 발생했습니다. 그래서 자료들을 찾아보니, 

```
spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code 
# authorization_grant_type을 authorization-grant-type으로 수정

# Provider 설정
spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize 
# authrization_uri를 authorization-uri로 수정

spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
# token_uri를 token-uri로 수정
spring.security.oauth2.client.provider.naver.user-name-attribute=response 
# user_name_attribute를 user-name-attribute로 수정
```

위처럼 코드를 수정하면 해결이 된다고 하여, 적용 후 문제 없이 실습을 진행할 수 있었습니다. 문제가 발생한 원인 및 해당 방법이 올바른 해결 방법인지 궁금합니다!
